### PR TITLE
v1.0.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { IPC_REQUEST_FOCUS, IPC_RESIZE, IPC_DIALOG, IPC_SHOW_MENU, IPC_MOVE, ELEC
 const { startServer } = require('./src/server')
 
 let windows = {}
+let sizes = {}
 let tray = null
 let id = 0
 let windowCount = 0;
@@ -32,9 +33,11 @@ function initWindow() {
   validDisplays.splice(2, validDisplays.length - 2)
 
 
-  sizeString = validDisplays.reduce((prev, curr) => {
-    const { width, height, x } = curr.workArea
-    return prev + `&${width}-${height}-${x}`
+  sizeString = validDisplays.reduce((prev, { scaleFactor, workArea }) => {
+    const { width, height, x } = workArea
+    const sWidth = parseInt(width * scaleFactor)
+    const sHeight = parseInt(height * scaleFactor)
+    return prev + `&${sWidth}-${sHeight}-${x}-${scaleFactor}`
   }, '')
 
 
@@ -230,6 +233,7 @@ function createWindow(resource) {
     window.show()
 
     windows[uuid] = window
+    sizes[uuid] = [100, 100]
 
     const targetResource = resource || process.argv.splice(1, 1)[0]
     window.webContents.send('launch', targetResource, app.getAppPath())
@@ -247,7 +251,12 @@ ipcMain.on(IPC_MOVE, (e, data) => {
   const { uuid, x, y } = data
   if (windows[uuid]) {
     try {
-      windows[uuid].setPosition(parseInt(x), parseInt(y))
+      const [width, height] = sizes[uuid]
+      windows[uuid].setBounds({
+        x: parseInt(x), y: parseInt(y),
+        width,
+        height,
+      })
     } catch (e) {
       console.log(e)
     }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ if (!lock) {
   app.quit()
   return
 } else {
+  app.commandLine.appendSwitch('high-dpi-support', 1)
+  app.commandLine.appendSwitch('force-device-scale-factor', 1)
   app.on(ELECTRON_SECOND_INSTANCE, (e, argv) => {
     const ptc = argv.find((arg) => arg.endsWith(CUSTOM_FILE_EXTENSION))
     createWindow(ptc)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petitcon",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "index.js",
   "author": "esllo",
   "license": "MIT",

--- a/src/hash-parser.js
+++ b/src/hash-parser.js
@@ -1,14 +1,15 @@
 const [uuid, ...sizeString] = location.hash.substring(1).split('&')
 
 const sizes = sizeString.map(string => string.split('-').map(str => Number(str)))
-const [widths, heights, xes, totalWidth] = sizes.reduce(([widths, heights, xes, totalWidth], [width, height, x]) => {
+const [widths, heights, xes, totalWidth, scales] = sizes.reduce(([widths, heights, xes, totalWidth, scales], [width, height, x, scale]) => {
   return [
     [...widths, width],
     [...heights, height],
     [...xes, x],
-    totalWidth + width
+    totalWidth + width,
+    [...scales, scale]
   ]
-}, [[], [], [], 0])
+}, [[], [], [], 0, []])
 
 module.exports = {
   uuid,
@@ -16,4 +17,5 @@ module.exports = {
   heights,
   xes,
   totalWidth,
+  scales,
 }


### PR DESCRIPTION
Fix #5 #6 

윈도우 해상도 배율 사용 시 모코코가 계속 커지거나, 실제 화면보다 작은 영역에서 그려지던 내용 수정
```js
  app.commandLine.appendSwitch('high-dpi-support', 1)
  app.commandLine.appendSwitch('force-device-scale-factor', 1)
```